### PR TITLE
docs: Add Polymarket deployment documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
             { text: 'Backtesting', link: '/guide/backtesting' },
             { text: 'Optimization', link: '/guide/optimization' },
             { text: 'Allora AI Price Predictions', link: '/guide/allora' },
+            { text: 'Polymarket Strategies', link: '/guide/polymarket' },
             { text: 'Deployment', link: '/guide/strategy-deployment' },
           ]
         },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
             { text: 'Optimization', link: '/guide/optimization' },
             { text: 'Allora AI Price Predictions', link: '/guide/allora' },
             { text: 'Deployment', link: '/guide/strategy-deployment' },
+            { text: 'Polymarket Deployments', link: '/guide/polymarket-deployments' },
+            { text: 'Polymarket Strategies', link: '/guide/polymarket-strategies' },
           ]
         },
         {

--- a/docs/guide/backtesting.md
+++ b/docs/guide/backtesting.md
@@ -1,6 +1,6 @@
 # Strategy Backtesting
 
-Robonet backtests use the Jesse Framework with historical data from Hyperliquid. This guide covers execution, parameters, and result interpretation.
+Robonet backtests use the Jesse Framework with historical data from Hyperliquid. This guide covers execution, parameters, and result interpretation for perpetual futures strategies. For prediction market backtesting, see [Polymarket Strategies — Backtesting](/guide/polymarket#backtesting).
 
 ## Running Backtests
 
@@ -158,6 +158,7 @@ Validation (2024): -8% return, 0.3 Sharpe, 42% win rate
 
 - [Strategy Optimization](/guide/optimization) - Parameter tuning and grid search
 - [Allora Integration](/guide/allora) - Enhance strategies with ML predictions
-- [Deployment Guide](/guide/deployment) - Deploy validated strategies to production
+- [Polymarket Strategies](/guide/polymarket) - Prediction market strategy backtesting
+- [Deployment Guide](/guide/strategy-deployment) - Deploy validated strategies to production
 - [MCP Tools Reference](/guide/mcp-tools#run-backtest) - Complete API documentation
 - [Jesse Framework Docs](https://docs.jesse.trade/) - Underlying backtesting engine

--- a/docs/guide/billing.md
+++ b/docs/guide/billing.md
@@ -57,7 +57,7 @@ AI tools show a maximum price, but typically cost much less. For example, "creat
 :::
 
 #### Deployment Tools ($1.00)
-- **Create deployment** - $1.00: Create new deployment (EOA or Hyperliquid Vault)
+- **Create deployment** - $1.00: Create new deployment (EOA, Hyperliquid Vault, or Polymarket Vault)
 - **List deployments** - Free: View your deployments
 - **Start live trading** - Free: Activate a deployed strategy
 - **Stop live trading** - Free: Stop a running strategy

--- a/docs/guide/chat-interface.md
+++ b/docs/guide/chat-interface.md
@@ -10,6 +10,7 @@ The chat interface provides a conversational way to:
 - Run backtests and analyze results
 - Optimize strategy parameters
 - Integrate Allora Network price predictions
+- Build and test Polymarket prediction market strategies
 - Deploy strategies to live trading
 
 For traders who prefer natural language over code.
@@ -41,9 +42,10 @@ After authentication, Robonet uses Privy for secure wallet management:
 
 #### Network Information
 
-- **Trading**: All trades execute on Hyperliquid Perpetuals (Hyperliquid L1)
+- **Hyperliquid Trading**: Perpetual futures execute on Hyperliquid L1
+- **Polymarket**: Prediction market strategies execute on Polygon via Gnosis Safe
 - **Payments**: Credits are managed on Base network (USDC)
-- **Settlement**: All trades settle on-chain on Hyperliquid
+- **Settlement**: All trades settle on-chain (Hyperliquid L1 or Polygon)
 - Your chat sessions and strategies are linked to your wallet address
 
 ### 2. Starting a Chat Session
@@ -303,8 +305,15 @@ You: Create a prediction market strategy for BTC price in February 2026
 The AI will:
 1. Call `get_prediction_market_data` to fetch market timeseries
 2. Analyze YES/NO token pricing trends
-3. Generate a strategy to trade prediction markets
+3. Generate a `PolymarketStrategy` with `should_buy_yes()`, `should_buy_no()`, `go_yes()`, and `go_no()` methods
 4. Backtest on historical prediction market data
+
+You can also explore and backtest on existing markets:
+
+```
+You: What prediction markets are available for crypto?
+You: Backtest my ValueBuyer strategy on BTC 15m rolling markets from Jan to March
+```
 
 **Prediction Market Card:**
 
@@ -313,6 +322,8 @@ View prediction market data directly in chat:
 - Market resolution status
 - High/low/current prices
 - Interactive dual-token chart
+
+For comprehensive details on Polymarket strategy development and deployment, see the [Polymarket Strategies guide](/guide/polymarket).
 
 **Screenshot placeholder:** Prediction market card with YES/NO token timeseries
 
@@ -325,7 +336,7 @@ Once you're satisfied with backtest results, deploy your strategy to live tradin
 ### Deployment Types
 
 **EOA (Externally Owned Account):**
-- Trades directly with your connected wallet
+- Trades directly with your connected wallet on Hyperliquid
 - Maximum 1 active deployment per user
 - Immediate setup, no minimum balance
 - Suited for: Testing with small capital
@@ -335,6 +346,14 @@ Once you're satisfied with backtest results, deploy your strategy to live tradin
 - Unlimited vaults per user
 - Requires 200 USDC minimum
 - Suited for: Production trading with larger capital
+
+**Polymarket Vault:**
+- Deploys an ERC-4626 vault on Polygon with a Gnosis Safe
+- Maximum 1 active Polymarket deployment per user
+- Requires ~10 POL for gas + 10 USDC.e for trading
+- Other users can deposit into your vault
+- Suited for: Prediction market strategies
+- See [Polymarket Strategies guide](/guide/polymarket#deploying-a-polymarket-strategy) for details
 
 ### Creating a Deployment
 
@@ -413,8 +432,9 @@ You: Start the MomentumRSI deployment again
 
 - **EOA Deployments**: Only 1 active at a time (must stop existing before starting a new one)
 - **Hyperliquid Vault Deployments**: Unlimited active deployments
+- **Polymarket Deployments**: 1 active at a time, requires POL on Polygon for gas
 - **Wallet Delegation Required**: Must authorize delegation before deploying
-- **Insufficient Balance**: Deployment will fail if insufficient USDC in wallet
+- **Insufficient Balance**: Deployment will fail if insufficient funds in wallet
 
 **Error Handling:**
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -32,6 +32,9 @@ Fine-tune your strategy parameters using automated optimization. Find the best c
 ### Allora Network Integration
 Leverage decentralized price predictions from the Allora Network as signals in your strategies. Access crowd-sourced market intelligence.
 
+### Polymarket Strategies
+Build and deploy automated prediction market strategies on Polymarket. Trade YES/NO tokens on real-world events with ERC-4626 vault infrastructure on Polygon.
+
 ### Deployment
 Deploy your strategies to production with one click. Robonet handles hosting, execution, and monitoring.
 

--- a/docs/guide/mcp-tools.md
+++ b/docs/guide/mcp-tools.md
@@ -479,16 +479,16 @@ Tools for deploying and managing live trading agents on Hyperliquid.
 
 ### `deployment_create`
 
-**Description:** Deploy a strategy to live trading on Hyperliquid.
+**Description:** Deploy a strategy to live trading on Hyperliquid or Polymarket.
 
 **Primary Use Case:** Launch automated trading with your backtested strategy.
 
 **Parameters:**
 - `strategy_name` (required, string): Name of strategy to deploy
-- `symbol` (required, string): Trading pair (e.g., "BTC-USDT")
-- `timeframe` (required, string): Candle interval (1m, 5m, 15m, 30m, 1h, 2h, 4h, 6h, 12h, 1d)
-- `leverage` (optional, number, 1-5): Position multiplier (default: 1)
-- `deployment_type` (optional, string): "eoa" (wallet) or "vault" (default: eoa)
+- `symbol` (required, string): Trading pair (e.g., "BTC-USDT") or **market slug** for Polymarket (e.g., "btc-up-or-down-15m")
+- `timeframe` (required, string): Candle interval (1m, 5m, 15m, 30m, 1h, 2h, 4h, 6h, 12h, 1d). **Polymarket: fixed to 1m**
+- `leverage` (optional, number, 1-5): Position multiplier (default: 1). **Polymarket: fixed to 1.0**
+- `deployment_type` (optional, string): "eoa" (wallet), "vault" (Hyperliquid), or "polymarket" (Polymarket vault)
 - `vault_name` (required for vault, string): Unique name for the Hyperliquid vault
 - `vault_description` (optional, string): Description for the vault
 
@@ -499,10 +499,19 @@ Tools for deploying and managing live trading agents on Hyperliquid.
 **Constraints:**
 - EOA: Maximum 1 active deployment per wallet
 - Hyperliquid Vault: Requires 200+ USDC in wallet, unlimited deployments
+- Polymarket: Maximum 1 active deployment per user, requires 10 POL on Polygon
+
+::: tip Polymarket Deployments
+For Polymarket, the `symbol` parameter is a **market slug** (e.g., `btc-up-or-down-15m`), not a trading pair. Timeframe is fixed to `1m` and leverage is fixed to `1.0`. Use `get_all_prediction_events` to find available market slugs. See [Polymarket Deployments](/guide/polymarket-deployments) for full details.
+:::
 
 **Example Usage:**
 ```
+# Hyperliquid
 Deploy MomentumRSI_M to BTC-USDT on 4h timeframe with 2x leverage
+
+# Polymarket
+Deploy ValueBuyer_PM_M to btc-up-or-down-15m on 1m timeframe
 ```
 
 ---

--- a/docs/guide/mcp-tools.md
+++ b/docs/guide/mcp-tools.md
@@ -583,6 +583,84 @@ Stop my BTC-USDT deployment
 
 ---
 
+### `agent_details`
+
+**Description:** Get agent stats for a Polymarket or Hyperliquid agent.
+
+**Primary Use Case:** View vault status, TVL, performance metrics, and configuration for a deployed agent.
+
+**Parameters:**
+- `agent_id` (required, string): Agent vault contract address (e.g., `0x...`)
+- `agent_type` (required, string): `polymarket` or `hyperliquid`
+
+**Returns:** Agent name, status, and type-specific details:
+- **Polymarket:** Vault TVL, price per share, performance fee, active/shutdown status, pending withdrawals
+- **Hyperliquid:** Account value, open positions, follower count
+
+**Pricing:** Free
+
+---
+
+### `agent_deposit`
+
+**Description:** Deposit USDC into a Polymarket or Hyperliquid agent.
+
+**Primary Use Case:** Fund a live trading agent after deployment.
+
+**Parameters:**
+- `agent_id` (required, string): Agent vault contract address
+- `amount` (required, number): Amount of USDC to deposit
+- `agent_type` (required, string): `polymarket` or `hyperliquid`
+
+**Returns:** Deposit confirmation with transaction details.
+
+::: tip Polymarket Deposits
+For Polymarket agents, deposits go through an ERC-20 approval flow on Polygon. Ensure you have USDC.e and POL for gas on the Polygon network. Use `user_position` to check balances before depositing.
+:::
+
+**Pricing:** Free
+
+---
+
+### `agent_withdraw`
+
+**Description:** Withdraw from a Polymarket or Hyperliquid agent.
+
+**Primary Use Case:** Retrieve funds from a live trading agent.
+
+**Parameters:**
+- `agent_id` (required, string): Agent vault contract address
+- `agent_type` (required, string): `polymarket` or `hyperliquid`
+- `shares_amount` (optional, number): Number of vault shares to withdraw (**Polymarket only**)
+- `amount_usdc` (optional, number): USDC amount to withdraw (**Hyperliquid only**)
+- `withdraw_all` (optional, boolean): Withdraw entire position (both types)
+
+::: tip Polymarket Withdrawals
+Polymarket withdrawals are share-based, not USDC-based. Use `user_position` to check your share balance first. You can specify `shares_amount` or set `withdraw_all=true`.
+:::
+
+**Pricing:** Free
+
+---
+
+### `user_position`
+
+**Description:** Get your current position in a Polymarket or Hyperliquid agent.
+
+**Primary Use Case:** Check balances, share holdings, and pending withdrawals before depositing or withdrawing.
+
+**Parameters:**
+- `agent_id` (required, string): Agent vault contract address
+- `agent_type` (required, string): `polymarket` or `hyperliquid`
+
+**Returns:** Position details including:
+- **Polymarket:** Wallet USDC.e and POL balances, vault share balance, available deposit/withdraw limits, pending withdrawal status, price per share, vault active status, on-chain performance fee
+- **Hyperliquid:** Wallet balance, vault equity, PnL
+
+**Pricing:** Free
+
+---
+
 ## Account Tools
 
 Tools for managing credits and viewing account information.

--- a/docs/guide/mcp-tools.md
+++ b/docs/guide/mcp-tools.md
@@ -394,9 +394,9 @@ Use create_prediction_market_strategy to build a "PriceThreshold" strategy that:
 
 **Returns:** List of prediction events with:
 - Event name and category
-- Associated markets with condition IDs
-- Market questions and outcomes (YES/NO)
-- Resolution status
+- `slug_pattern` and `event_slug` — use these to identify valid market slugs for `deployment_create`
+- Associated markets with condition IDs and questions
+- Discovery config and active/backfilled status
 
 **Pricing:** Tier 1 - Data Access ($0.001)
 
@@ -491,8 +491,11 @@ Tools for deploying and managing live trading agents on Hyperliquid.
 - `deployment_type` (optional, string): "eoa" (wallet), "vault" (Hyperliquid), or "polymarket" (Polymarket vault)
 - `vault_name` (required for vault, string): Unique name for the Hyperliquid vault
 - `vault_description` (optional, string): Description for the vault
+- `performance_fee_pct` (optional, number, 5-50, default: 10): Performance fee percentage — **Polymarket only**. Stored on-chain in basis points (10% = 1000 BPS).
+- `total_assets_limit` (optional, number): Maximum vault TVL in USDC.e — **Polymarket only**
+- `max_deposit_per_wallet` (optional, number): Per-wallet deposit cap in USDC.e — **Polymarket only**
 
-**Returns:** Deployment ID, status, wallet address, and configuration details.
+**Returns:** Deployment ID, status, wallet address, agent ID (vault contract address), and configuration details.
 
 **Pricing:** $0.50
 
@@ -502,7 +505,7 @@ Tools for deploying and managing live trading agents on Hyperliquid.
 - Polymarket: Maximum 1 active deployment per user, requires 10 POL on Polygon
 
 ::: tip Polymarket Deployments
-For Polymarket, the `symbol` parameter is a **market slug** (e.g., `btc-up-or-down-15m`), not a trading pair. Timeframe is fixed to `1m` and leverage is fixed to `1.0`. Use `get_all_prediction_events` to find available market slugs. See [Polymarket Deployments](/guide/polymarket-deployments) for full details.
+For Polymarket, the `symbol` parameter is a **market slug** (e.g., `btc-up-or-down-15m`), not a trading pair. Timeframe is fixed to `1m` and leverage is fixed to `1.0`. Use `get_all_prediction_events` to discover slugs — look for `slug_pattern` (rolling markets) or `event_slug` (single events) in the response. See [Polymarket Deployments](/guide/polymarket-deployments) for full details.
 :::
 
 **Example Usage:**
@@ -583,6 +586,10 @@ Stop my BTC-USDT deployment
 
 ---
 
+::: tip Finding Your agent_id
+The `agent_id` (vault contract address) is returned by `deployment_create` when you first deploy. You can also find it in the `deployment_list` output or in the Robonet web UI under your deployment details. All four tools below (`agent_details`, `agent_deposit`, `agent_withdraw`, `user_position`) require it.
+:::
+
 ### `agent_details`
 
 **Description:** Get agent stats for a Polymarket or Hyperliquid agent.
@@ -603,9 +610,9 @@ Stop my BTC-USDT deployment
 
 ### `agent_deposit`
 
-**Description:** Deposit USDC into a Polymarket or Hyperliquid agent.
+**Description:** Deposit USDC (Hyperliquid) or USDC.e (Polymarket) into a live trading agent.
 
-**Primary Use Case:** Fund a live trading agent after deployment.
+**Primary Use Case:** Fund a live trading agent after deployment. An "agent" is a deployed strategy instance; the `agent_id` is the vault contract address.
 
 **Parameters:**
 - `agent_id` (required, string): Agent vault contract address
@@ -624,7 +631,7 @@ For Polymarket agents, deposits go through an ERC-20 approval flow on Polygon. E
 
 ### `agent_withdraw`
 
-**Description:** Withdraw from a Polymarket or Hyperliquid agent.
+**Description:** Withdraw USDC (Hyperliquid) or USDC.e (Polymarket) from a live trading agent.
 
 **Primary Use Case:** Retrieve funds from a live trading agent.
 

--- a/docs/guide/polymarket-deployments.md
+++ b/docs/guide/polymarket-deployments.md
@@ -227,7 +227,11 @@ Polymarket vaults support a configurable **performance fee** set at deployment t
 
 | Fee | Description |
 |-----|-------------|
-| **Performance fee** | Percentage of profits taken as fee, configured in basis points (BPS). E.g., 500 BPS = 5% of profits. Set via `performance_fee_pct` parameter (1-20%). Applied during `report()`. |
+| **Performance fee** | Percentage of profits taken as fee, configured in basis points (BPS). E.g., 500 BPS = 5% of profits. Set via `performance_fee_pct` parameter (5-50%, default 10%). Applied during `report()`. |
+
+::: info Fee Range Note
+The MCP tool (`deployment_create`) accepts performance fees from **5-50%** with a default of **10%**. The backend API historically accepted 1-20%. When deploying via MCP tools, the 5-50% range applies.
+:::
 
 There is no management fee or deposit/withdrawal fee at the vault level. Polymarket's CLOB charges a **2% taker fee** on trades.
 

--- a/docs/guide/polymarket-deployments.md
+++ b/docs/guide/polymarket-deployments.md
@@ -1,0 +1,323 @@
+# Polymarket Deployments
+
+This guide covers how to deploy trading agents on **Polymarket** — a prediction market platform where agents trade YES/NO binary outcome tokens. Polymarket deployments use a fundamentally different architecture from Hyperliquid, running on Polygon with ERC4626 vaults and Safe wallets.
+
+---
+
+## Overview
+
+Polymarket deployments let your agent trade on prediction markets — events with binary YES/NO outcomes like "Will BTC be above $100k on March 15?" Your agent buys and sells YES and NO tokens based on your strategy logic, and the vault manages deposits, withdrawals, and accounting on-chain.
+
+Unlike Hyperliquid deployments that use perpetual futures on a custom L1, Polymarket deployments operate on the **Polygon** network using:
+
+- A **Safe wallet** for secure on-chain operations
+- An **ERC4626 vault** (Yearn TokenizedStrategy) for share-based deposit/withdrawal accounting
+- The **Polymarket CLOB** (Central Limit Order Book) for order execution
+
+::: info One Active Deployment
+Each user can have **one active Polymarket deployment** at a time. Stop your existing deployment before creating a new one.
+:::
+
+---
+
+## Prerequisites
+
+Before deploying a Polymarket agent, ensure you have:
+
+| Requirement | Details |
+|-------------|---------|
+| **Privy wallet delegation** | Grant delegation in the Robonet app (same as Hyperliquid) |
+| **10 POL minimum** | In your Privy wallet on Polygon — covers vault contract deployment gas (~0.3 POL) plus post-deployment config calls |
+| **USDC.e on Polygon** | Trading capital deposited into the vault after deployment |
+| **Robonet credits** | For platform usage (purchased with USDC on Base, same as always) |
+
+::: warning POL Gas Requirement
+Safe deployment and token approvals are gasless (handled by a relayer), but the vault contract deployment itself requires POL. Make sure you have at least 10 POL in your wallet on the Polygon network (Chain ID 137).
+:::
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     POLYMARKET DEPLOYMENT ARCHITECTURE                       │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ┌──────────┐     ┌──────────────┐     ┌──────────────┐     ┌───────────┐ │
+│   │   YOU    │ ──→ │   ROBONET    │ ──→ │   POLYGON    │ ──→ │POLYMARKET │ │
+│   │  (User)  │     │   PLATFORM   │     │   NETWORK    │     │   CLOB    │ │
+│   └──────────┘     └──────────────┘     └──────────────┘     └───────────┘ │
+│                                                                             │
+│   • Deploy agent     • Setup Safe       • ERC4626 Vault    • Order         │
+│   • Deposit USDC.e   • Deploy vault     • Share accounting   matching      │
+│   • Withdraw funds   • Run strategy     • On-chain settle  • YES/NO        │
+│                      • Vault lifecycle    ment                tokens        │
+│                                                                             │
+│                     ┌──────────────┐                                        │
+│                     │  SAFE WALLET │ ← Derived from Privy wallet            │
+│                     │  (Polygon)   │   Holds CLOB positions & USDC.e        │
+│                     └──────────────┘                                        │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key components:**
+
+- **Privy Wallet** — Your embedded wallet handles signing via delegated access
+- **Safe Wallet** — A smart contract wallet on Polygon derived from your Privy wallet. Holds trading funds and interacts with the CLOB
+- **ERC4626 Vault** — On-chain vault contract (Yearn TokenizedStrategy pattern) that manages share-based deposits and withdrawals
+- **Polymarket CLOB** — The off-chain orderbook where your agent places trades. API credentials are derived when the agent starts trading (not pre-created at deployment)
+
+---
+
+## Deployment Setup Flow
+
+When you create a Polymarket deployment, the platform runs through these steps automatically:
+
+```
+1. Validate user       → Check delegation, embedded wallet
+2. Check POL balance   → Require ≥ 10 POL on Polygon
+3. Deploy Safe         → Derive + deploy Safe wallet (gasless via relayer)
+4. Set approvals       → On-chain token approvals for USDC.e + CTF
+5. Deploy vault        → Deploy ERC4626 vault contract (costs ~0.3 POL)
+6. Approve vault       → Authorize vault on Safe (CRITICAL for withdrawals)
+7. Package config      → Store vault/Safe addresses, fee config
+```
+
+::: danger Safe-Vault Approval
+Step 6 — approving the vault on the Safe — is critical. Without this approval, the vault cannot fulfill withdrawal requests. If this step fails, the deployment setup will error and must be retried.
+:::
+
+**CLOB API credentials** are not created during deployment. They are derived by the agent when it starts trading. This means the agent must successfully initialize before it can place orders on the Polymarket orderbook.
+
+---
+
+## Vault Mechanics
+
+### ERC4626 / TokenizedStrategy
+
+Polymarket vaults follow the [ERC4626](https://eips.ethereum.org/EIPS/eip-4626) tokenized vault standard, using the Yearn TokenizedStrategy pattern. Key concepts:
+
+- **Shares** — When you deposit USDC.e, you receive vault shares proportional to the current Price Per Share (PPS)
+- **PPS (Price Per Share)** — The vault's share price, updated each vault cycle via `report()`. Starts at 1.0 and changes based on strategy performance
+- **Total Assets** — The total USDC.e value managed by the vault (positions + idle balance)
+
+### Capacity & Limits
+
+Each vault has configurable capacity limits:
+
+| Limit | Description |
+|-------|-------------|
+| `total_assets_limit` | Maximum total USDC.e the vault can hold (TVL cap) |
+| `max_deposit_per_wallet` | Maximum deposit per individual wallet |
+
+The deposit UI shows a capacity indicator. When the vault is at capacity, new deposits are rejected.
+
+### Units and Decimals
+
+::: warning USDC.e Uses 6 Decimals
+USDC.e on Polygon uses **6 decimal places**. Raw amounts in contract calls use 6-decimal integers (e.g., `1000000` = 1.00 USDC.e). Share amounts also use raw integer representation. Always verify units when interacting with the vault contract directly.
+:::
+
+---
+
+## Deposit Flow
+
+Depositing USDC.e into a Polymarket vault:
+
+```
+1. Connect wallet on Polygon network
+2. Enter deposit amount (USDC.e)
+3. previewDeposit() → Shows shares you'll receive at current PPS
+4. Approve USDC.e spending (if not already approved)
+5. Call deposit() on vault contract
+6. Vault mints shares to your address
+7. Capacity indicator updates
+```
+
+**Requirements:**
+- Wallet connected to Polygon (Chain ID 137)
+- Sufficient USDC.e balance
+- Vault must be **active** (not deactivated) — deposits are rejected on deactivated vaults
+- Deposit must not exceed `max_deposit_per_wallet` or push total assets past `total_assets_limit`
+
+---
+
+## Withdrawal Flow
+
+Withdrawals work differently depending on whether the vault is **active** or **deactivated**. These are two separate paths — do not confuse them.
+
+### Active Vault — Request & Queue
+
+When the vault is active (agent is running), withdrawals go through a request queue:
+
+```
+1. Enter shares to withdraw
+2. Call requestWithdraw(shares) on vault contract
+3. Withdrawal request is QUEUED
+4. Next hourly vault cycle processes the request:
+   a. tend()  → Sync positions and prices
+   b. report() → Finalize accounting, update PPS
+   c. processWithdrawals() → Fulfill queued requests
+5. USDC.e transferred to your wallet
+```
+
+::: info Processing Time
+Withdrawal requests are processed during the next hourly vault cycle. In the worst case, you may wait up to ~1 hour for fulfillment. The UI shows a pending withdrawal panel while you wait.
+:::
+
+### Deactivated Vault — Direct Redeem
+
+When the vault is deactivated (agent has been stopped), you can withdraw immediately:
+
+```
+1. Enter shares to withdraw
+2. Call redeem(shares) on vault contract
+3. USDC.e transferred to your wallet immediately
+4. No queue, no waiting for vault cycle
+```
+
+The UI automatically detects the vault's on-chain `isActive` state and shows the appropriate withdrawal form:
+- **Active vault** → Standard withdrawal request form + pending panel
+- **Deactivated vault** → Direct withdrawal form with immediate redemption, deposit tab disabled
+
+::: tip After Stopping an Agent
+When you stop a Polymarket agent, the vault is deactivated. A red banner appears: "Agent Stopped — Vault Deactivated." You can withdraw your funds directly without waiting for a vault cycle.
+:::
+
+---
+
+## Hourly Vault Lifecycle
+
+The vault manager runs an hourly cycle in a background daemon thread alongside the trading engine:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    HOURLY VAULT CYCLE                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   1. tend()                                                     │
+│      └─ Collect current positions from Polymarket Data API      │
+│      └─ Submit position data + prices to vault contract         │
+│      └─ Updates vault's view of total assets                    │
+│                                                                 │
+│   2. report()                                                   │
+│      └─ Finalize accounting (profit/loss since last report)     │
+│      └─ Update Price Per Share (PPS)                            │
+│      └─ Apply performance fees if applicable                    │
+│                                                                 │
+│   3. processWithdrawals()                                       │
+│      └─ Fulfill queued withdrawal requests                      │
+│      └─ Transfer USDC.e to requestors                           │
+│                                                                 │
+│   Interval: Every 3600 seconds (1 hour)                         │
+│   If tend() fails: entire cycle is SKIPPED (safety measure)     │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+The cycle is sequential and fail-safe: if `tend()` cannot reliably collect position data, the entire cycle is skipped to avoid reporting inaccurate values to the vault contract. Steps 2 and 3 only run if step 1 succeeds.
+
+---
+
+## Fees
+
+Polymarket vaults support a configurable **performance fee** set at deployment time:
+
+| Fee | Description |
+|-----|-------------|
+| **Performance fee** | Percentage of profits taken as fee, configured in basis points (BPS). E.g., 500 BPS = 5% of profits. Set via `performance_fee_pct` parameter (1-20%). Applied during `report()`. |
+
+There is no management fee or deposit/withdrawal fee at the vault level. Polymarket's CLOB charges a **2% taker fee** on trades.
+
+---
+
+## Constraints
+
+| Constraint | Detail |
+|------------|--------|
+| One active Polymarket deployment per user | Stop existing deployment before creating a new one |
+| Leverage fixed at 1.0x | No leverage available on prediction markets |
+| Timeframe fixed at 1m | Strategy execution runs on 1-minute candles |
+| Symbol = market slug | e.g., `btc-up-or-down-15m`, not a trading pair |
+| CLOB credentials derived at runtime | Agent creates them on startup, not during deployment |
+| Safe wallet persisted across deployments | Once created, your Safe address is reused |
+
+---
+
+## Error States & Troubleshooting
+
+### Deployment Errors
+
+**"Insufficient POL balance"**
+- Your wallet needs ≥ 10 POL on Polygon (Chain ID 137)
+- Safe deployment is gasless, but the vault contract deployment needs POL
+- Bridge POL to Polygon if needed
+
+**"Active deployment exists"**
+- You already have a running Polymarket deployment
+- Stop the existing one before creating a new deployment
+
+**"Safe setup failed"**
+- Privy wallet delegation may have been revoked
+- Re-grant delegation in the Robonet app and retry
+
+**"Vault deployment failed"**
+- Usually a gas issue — ensure sufficient POL
+- Can also indicate a Polygon network issue — retry after a few minutes
+
+**"Vault approval on Safe failed"**
+- Critical error — without this, withdrawals won't work
+- Retry the deployment. If it persists, contact support
+
+### Deposit Errors
+
+**"Deposit rejected"**
+- Vault may be deactivated (agent stopped) — deposits disabled
+- Vault may be at capacity — check the capacity indicator
+- Individual wallet deposit limit may be reached
+
+### Withdrawal Errors
+
+**"Withdrawal request failed"**
+- Ensure you have vault shares to withdraw
+- For active vaults, the request may fail if the vault contract has an issue
+- For deactivated vaults, direct redeem should always work if you hold shares
+
+**"Pending withdrawal not processed"**
+- Withdrawal requests on active vaults are processed hourly
+- If `tend()` fails (e.g., position data unavailable), the cycle is skipped
+- Check back after the next hour. If it persists, the agent logs will show the vault manager errors
+
+---
+
+## Polymarket vs Hyperliquid Comparison
+
+| Aspect | Hyperliquid | Polymarket |
+|--------|-------------|------------|
+| **Network** | Hyperliquid L1 | Polygon (Chain ID 137) |
+| **Asset type** | Perpetual futures | YES/NO binary outcome tokens |
+| **Vault standard** | Hyperliquid native vault | ERC4626 (Yearn TokenizedStrategy) |
+| **Wallet** | Direct EOA or HL vault | Safe wallet + CLOB API credentials |
+| **Deposit/Withdraw** | Via Hyperliquid API | On-chain ERC4626 on Polygon |
+| **Share price** | N/A (account value) | PPS from vault contract |
+| **Strategy base class** | `Strategy` | `PolymarketStrategy` (YES/NO methods) |
+| **Market lifecycle** | Continuous | Rolling with resolution events |
+| **Gas token** | N/A | POL (min 10 for deployment) |
+| **Stats sync** | Real-time via HL API | Hourly vault cycle reads Polygon |
+| **Deployment flow** | Create/delegate wallet | Safe → approvals → vault → CLOB creds at runtime |
+| **Deployments per user** | Multiple (EOA: 1, Vault: unlimited) | One active |
+| **Leverage** | Configurable (1-5x) | Fixed at 1.0x |
+| **Currency** | USDC | USDC.e (6 decimals, Polygon) |
+| **Fees** | Exchange trading fees | 2% CLOB taker fee + configurable vault performance fee |
+
+---
+
+## Related Documentation
+
+- [Polymarket Strategies](/guide/polymarket-strategies) — Build strategies for prediction markets
+- [Trading Venues](/guide/trading-venues) — Overview of all supported venues
+- [Wallet Integration](/guide/wallet) — Wallet setup including Polygon network
+- [Strategy Deployment](/guide/strategy-deployment) — General deployment guide
+- [MCP Tools Reference](/guide/mcp-tools) — Tool parameters for Polymarket deployments

--- a/docs/guide/polymarket-deployments.md
+++ b/docs/guide/polymarket-deployments.md
@@ -26,13 +26,17 @@ Before deploying a Polymarket agent, ensure you have:
 
 | Requirement | Details |
 |-------------|---------|
-| **Privy wallet delegation** | Grant delegation in the Robonet app (same as Hyperliquid) |
+| **Privy wallet delegation** | Grant delegation in the Robonet app (see security warning below) |
 | **10 POL minimum** | In your Privy wallet on Polygon — covers vault contract deployment gas (~0.3 POL) plus post-deployment config calls |
 | **USDC.e on Polygon** | Trading capital deposited into the vault after deployment |
 | **Robonet credits** | For platform usage (purchased with USDC on Base, same as always) |
 
+::: warning Security — Wallet Delegation
+Granting Privy wallet delegation allows the Robonet platform to sign transactions on your behalf — including deploying contracts, approving token spending, and executing trades. **Risks:** delegated access persists until explicitly revoked. To revoke, go to the Robonet app → Settings → Wallet → Revoke Delegation. Only delegate wallets you use exclusively for Robonet trading, and avoid holding large balances outside of vault deposits.
+:::
+
 ::: warning POL Gas Requirement
-Safe deployment and token approvals are gasless (handled by a relayer), but the vault contract deployment itself requires POL. Make sure you have at least 10 POL in your wallet on the Polygon network (Chain ID 137).
+**Safe deployment** and initial vault token approvals (deployment step 4) are gasless — handled by the Robonet relayer. However, the **vault contract deployment** itself requires POL. User-initiated deposits may also require POL for on-chain USDC.e approval transactions. Make sure you have at least 10 POL in your wallet on the Polygon network (Chain ID 137).
 :::
 
 ---
@@ -227,7 +231,7 @@ Polymarket vaults support a configurable **performance fee** set at deployment t
 
 | Fee | Description |
 |-----|-------------|
-| **Performance fee** | Percentage of profits taken as fee, configured in basis points (BPS). E.g., 500 BPS = 5% of profits. Set via `performance_fee_pct` parameter (5-50%, default 10%). Applied during `report()`. |
+| **Performance fee** | Percentage of profits taken as fee. Set via `performance_fee_pct` parameter as a **percentage** (5-50%, default 10%). The value is stored on-chain in basis points (e.g., 10% → 1000 BPS). Applied during `report()`. |
 
 ::: info Fee Range Note
 The MCP tool (`deployment_create`) accepts performance fees from **5-50%** with a default of **10%**. The backend API historically accepted 1-20%. When deploying via MCP tools, the 5-50% range applies.
@@ -294,6 +298,12 @@ There is no management fee or deposit/withdrawal fee at the vault level. Polymar
 - If `tend()` fails (e.g., position data unavailable), the cycle is skipped
 - Check back after the next hour. If it persists, the agent logs will show the vault manager errors
 
+**Repeated `tend()` failures**
+- If `tend()` fails for multiple consecutive cycles, positions may be stale and withdrawals blocked
+- **Emergency withdrawal:** Stop the deployment via `deployment_stop`, which deactivates the vault. Once deactivated, use `agent_withdraw` with `withdraw_all=true` to redeem shares directly
+- **View logs:** Agent logs are available in the Robonet web UI under Deployment → Logs, or via the platform API
+- **Contact support:** If the vault is stuck (e.g., cannot stop deployment or redeem shares), contact support with your vault address and agent ID
+
 ---
 
 ## Polymarket vs Hyperliquid Comparison
@@ -309,7 +319,7 @@ There is no management fee or deposit/withdrawal fee at the vault level. Polymar
 | **Strategy base class** | `Strategy` | `PolymarketStrategy` (YES/NO methods) |
 | **Market lifecycle** | Continuous | Rolling with resolution events |
 | **Gas token** | N/A | POL (min 10 for deployment) |
-| **Stats sync** | Real-time via HL API | Hourly vault cycle reads Polygon |
+| **Stats sync** | Real-time via HL API | Hourly vault cycle (Data API → Polygon) |
 | **Deployment flow** | Create/delegate wallet | Safe → approvals → vault → CLOB creds at runtime |
 | **Deployments per user** | Multiple (EOA: 1, Vault: unlimited) | One active |
 | **Leverage** | Configurable (1-5x) | Fixed at 1.0x |

--- a/docs/guide/polymarket-strategies.md
+++ b/docs/guide/polymarket-strategies.md
@@ -1,0 +1,366 @@
+# Polymarket Strategies
+
+This guide covers how to build trading strategies for Polymarket prediction markets. Polymarket strategies trade **YES/NO binary outcome tokens** — not perpetual futures — and use a dedicated base class with its own set of required methods.
+
+---
+
+## Overview
+
+Polymarket strategies inherit from `PolymarketStrategy` (not the standard `Strategy` class). The key difference: instead of going long or short on a perpetual, your strategy decides whether to buy YES tokens, NO tokens, or both — and when to sell them.
+
+Each candle tick, the engine calls your strategy's signal methods. If `should_buy_yes()` returns `True`, it calls `go_yes()` where you set your order. Same for NO tokens.
+
+::: warning Not Long/Short
+Polymarket uses **YES/NO binary tokens**, not long/short positions. Prices are probabilities between 0 and 1. A YES token at 0.70 means the market thinks there's a 70% chance the event happens.
+:::
+
+---
+
+## PolymarketStrategy Base Class
+
+```python
+from jesse.strategies import PolymarketStrategy
+
+class MyStrategy_PM_15m_M(PolymarketStrategy):
+    """My prediction market strategy"""
+
+    # Required methods (must implement all four)
+    def should_buy_yes(self) -> bool: ...
+    def should_buy_no(self) -> bool: ...
+    def go_yes(self) -> None: ...
+    def go_no(self) -> None: ...
+
+    # Optional overrides
+    def should_sell_yes(self) -> bool: ...
+    def should_sell_no(self) -> bool: ...
+    def on_resolution(self, winning_side: str) -> None: ...
+```
+
+### Required Methods
+
+You must implement all four of these:
+
+| Method | Purpose | When Called |
+|--------|---------|------------|
+| `should_buy_yes()` → `bool` | Signal to buy YES tokens | Each candle when not in a YES position |
+| `should_buy_no()` → `bool` | Signal to buy NO tokens | Each candle when not in a NO position |
+| `go_yes()` | Set `self.buy_yes = (qty, price)` | When `should_buy_yes()` returns `True` |
+| `go_no()` | Set `self.buy_no = (qty, price)` | When `should_buy_no()` returns `True` |
+
+### Optional Methods
+
+| Method | Purpose | Default Behavior |
+|--------|---------|------------------|
+| `should_sell_yes()` → `bool` | Signal to sell YES tokens | `False` (hold until resolution) |
+| `should_sell_no()` → `bool` | Signal to sell NO tokens | `False` (hold until resolution) |
+| `go_exit_yes()` | Set `self.sell_yes = (qty, price)` | Sell entire position at market price |
+| `go_exit_no()` | Set `self.sell_no = (qty, price)` | Sell entire position at market price |
+| `on_resolution(winning_side)` | Handle market resolution | No-op |
+| `on_open_position(order)` | Position opened callback | No-op |
+| `on_close_position(order)` | Position closed callback (`order=None` if resolution) | No-op |
+| `on_increased_position(order)` | Position size increased | No-op |
+| `on_reduced_position(order)` | Position size decreased | No-op |
+| `before()` | Called before strategy logic each candle | No-op |
+| `after()` | Called after strategy logic each candle | No-op |
+| `update_position()` | Called each candle when position is open | No-op |
+| `should_cancel_entry()` → `bool` | Cancel unfilled entry orders each candle | `True` |
+
+---
+
+## Key Properties
+
+### Price Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.yes_price` | `float` | Current YES token price (0 to 1) |
+| `self.no_price` | `float` | Current NO token price (0 to 1) |
+| `self.price` | `float` | Alias for YES price (from candle data) |
+
+### Position Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.yes_position` | `PolymarketPosition` | YES token position object |
+| `self.no_position` | `PolymarketPosition` | NO token position object |
+
+Each position object has these attributes:
+
+```python
+self.yes_position.is_open       # bool — position currently open?
+self.yes_position.qty           # float — token quantity held
+self.yes_position.avg_price     # float — average entry price
+self.yes_position.value         # float — current value in USDC
+self.yes_position.pnl           # float — unrealized profit/loss
+self.yes_position.current_price # float — current token price
+```
+
+### Balance Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.available_margin` | `float` | Available USDC for new positions |
+| `self.balance` | `float` | Total USDC wallet balance |
+| `self.total_position_value` | `float` | Combined YES + NO position value |
+| `self.total_pnl` | `float` | Combined unrealized PnL |
+
+### Market Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.market` | `PolymarketMarket` | Market metadata (question, outcomes, asset, interval) |
+| `self.is_resolved` | `bool` | Whether the market has resolved |
+| `self.resolution` | `str \| None` | Resolution outcome: `'yes'`, `'no'`, or `None` |
+
+### Trade Tracking
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.trades` | `list` | List of completed `PolymarketClosedTrade` objects |
+| `self.last_pm_trade` | object | Most recent completed trade |
+| `self.pm_trades_count` | `int` | Number of completed trades |
+
+---
+
+## Price Constraints
+
+Polymarket token prices are **probabilities**:
+
+- Prices must be between **0 and 1** (exclusive)
+- `YES price + NO price ≈ 1.0` (they sum to approximately 1.0)
+- A YES token at **0.75** means the market prices a 75% probability the event occurs
+- A NO token at **0.25** means a 25% probability the event does NOT occur
+
+::: danger Prices Are Not Dollar Amounts
+Do **not** multiply prices by 100 or treat them as dollar values. `0.75` means 75 cents per token, not $75. If you set `self.buy_yes = (qty, 0.75 * 100)`, your order will be rejected.
+:::
+
+---
+
+## Resolution Mechanics
+
+When a prediction market resolves:
+
+- **Winning token** → redeemable at **$1.00** per token
+- **Losing token** → worth **$0.00**
+
+For example, if you hold 100 YES tokens and the market resolves YES:
+- Your 100 YES tokens are worth 100 × $1.00 = $100.00
+- Any NO tokens you held are worth $0.00
+
+The `on_resolution(winning_side)` callback fires with `'yes'` or `'no'` so your strategy can log or react to the outcome.
+
+---
+
+## Rolling Markets
+
+Rolling markets are sequential, time-bounded prediction markets on the same underlying asset. For example, "Will BTC go up in the next 15 minutes?" repeats every 15 minutes as a new market.
+
+**Key behaviors:**
+- Your strategy auto-transitions to the next market when the current one resolves
+- Resolution settlement happens automatically — winning tokens pay out $1.00, losing tokens expire
+- Balance carries forward between markets
+- The agent exits positions **60 seconds before resolution** to avoid holding through settlement
+- Rolling markets have an `asset` (e.g., "BTC") and `interval` (e.g., "15m")
+
+### Market Slugs
+
+Polymarket markets are identified by slugs, not trading pairs:
+
+| Slug Example | Description |
+|-------------|-------------|
+| `btc-up-or-down-15m` | BTC price direction, 15-minute rolling |
+| `eth-up-or-down-1h` | ETH price direction, 1-hour rolling |
+| `will-btc-hit-100k-by-march` | One-time event market |
+
+When deploying via the MCP server or API, use the market slug as the `symbol` parameter.
+
+---
+
+## Naming Convention
+
+Polymarket strategies follow this naming pattern:
+
+```
+{StrategyName}_PM_{Risk}
+```
+
+| Component | Description | Examples |
+|-----------|-------------|----------|
+| `StrategyName` | Descriptive name | `ValueBuyer`, `MomentumTrader` |
+| `PM` | Indicates Polymarket strategy | Always `PM` |
+| `Risk` | Risk level suffix | `L` (low), `M` (medium), `H` (high) |
+
+**Risk levels for prediction markets:**
+
+| Level | Margin per Trade | Entry Threshold |
+|-------|-----------------|-----------------|
+| **Low (L)** | 25-30% of available margin | Tight — enter only when price < 0.30 |
+| **Medium (M)** | 40-50% of available margin | Moderate — enter when price < 0.45 |
+| **High (H)** | 60-80% of available margin | Aggressive — enter when price < 0.50 |
+
+**Examples:** `ValueBuyer_PM_M`, `PriceThreshold_PM_L`, `MomentumTrader_PM_H`
+
+---
+
+## Backtesting
+
+### Single Market Backtest
+
+Test your strategy against one specific market by its condition ID:
+
+```
+Use run_prediction_market_backtest on "ValueBuyer_PM_M"
+  with condition_id="0xb0eb..."
+  from 2025-01-01 to 2025-01-30
+```
+
+### Rolling Market Backtest
+
+Test across a series of rolling markets for an asset and interval:
+
+```
+Use run_prediction_market_backtest on "ValueBuyer_PM_M"
+  with asset="BTC" interval="15m"
+  from 2025-01-01 to 2025-01-15
+```
+
+Rolling backtests chain multiple markets together, carrying balance forward through resolution settlements — just like live trading.
+
+Use the `get_data_availability` MCP tool with `data_type="polymarket"` to check which markets have historical data before backtesting.
+
+---
+
+## Example Strategy
+
+Here's a complete strategy that buys undervalued tokens — YES tokens when the market underprices the event, NO tokens when it overprices:
+
+```python
+from jesse.strategies import PolymarketStrategy
+
+
+class ValueBuyer_PM_M(PolymarketStrategy):
+    """
+    Buy YES when price is low (undervalued), buy NO when YES price
+    is high (overvalued). Sell when price moves toward fair value.
+    Medium risk: 50% margin per trade, moderate thresholds.
+    """
+
+    # --- Required: Entry signals ---
+
+    def should_buy_yes(self) -> bool:
+        """Buy YES when it's cheap (< 0.40) and we don't already hold"""
+        return not self.yes_position.is_open and self.yes_price < 0.40
+
+    def should_buy_no(self) -> bool:
+        """Buy NO when YES is expensive (> 0.60) and we don't already hold"""
+        return not self.no_position.is_open and self.no_price < 0.40
+
+    # --- Required: Entry execution ---
+
+    def go_yes(self) -> None:
+        """Use 50% of available margin for YES position"""
+        qty = (self.available_margin * 0.5) / self.yes_price
+        self.buy_yes = (qty, self.yes_price)
+
+    def go_no(self) -> None:
+        """Use 50% of available margin for NO position"""
+        qty = (self.available_margin * 0.5) / self.no_price
+        self.buy_no = (qty, self.no_price)
+
+    # --- Optional: Exit signals ---
+
+    def should_sell_yes(self) -> bool:
+        """Take profit when YES moves above 0.60"""
+        return self.yes_position.is_open and self.yes_price > 0.60
+
+    def should_sell_no(self) -> bool:
+        """Take profit when NO moves above 0.60"""
+        return self.no_position.is_open and self.no_price > 0.60
+
+    # --- Optional: Resolution handling ---
+
+    def on_resolution(self, winning_side: str) -> None:
+        """Log resolution outcome"""
+        pass
+```
+
+**What this strategy does:**
+
+1. Watches YES and NO token prices each minute (1m candles)
+2. If YES is trading below 0.40 — buys YES tokens with 50% of available capital
+3. If NO is trading below 0.40 — buys NO tokens with 50% of available capital
+4. Takes profit when either token climbs above 0.60
+5. If neither exit triggers, positions resolve at market end (winning = $1.00, losing = $0.00)
+
+**Position sizing:** `qty = margin_amount / token_price`. At a YES price of 0.35 with $5,000 margin, you'd buy ~14,285 YES tokens.
+
+---
+
+## Common Mistakes
+
+```python
+# ❌ WRONG — Using regular Strategy base class
+from jesse.strategies import Strategy  # Should be PolymarketStrategy
+
+# ❌ WRONG — Using long/short methods
+def should_long(self): ...    # Should be should_buy_yes
+def should_short(self): ...   # Should be should_buy_no
+self.buy = (qty, price)       # Should be self.buy_yes or self.buy_no
+
+# ❌ WRONG — Price not in 0-1 range
+self.buy_yes = (qty, 0.75 * 100)  # 75 is wrong, use 0.75
+
+# ❌ WRONG — Using wrong position object
+if self.position.is_open: ...  # Should be self.yes_position.is_open
+
+# ✅ CORRECT
+from jesse.strategies import PolymarketStrategy
+
+def should_buy_yes(self) -> bool:
+    return not self.yes_position.is_open and self.yes_price < 0.45
+```
+
+---
+
+## Order Execution Reference
+
+```python
+# Buy YES tokens — tuple (quantity, price) or list of tuples
+self.buy_yes = (qty, price)
+self.buy_yes = [(qty1, price1), (qty2, price2)]  # Multiple orders
+
+# Buy NO tokens
+self.buy_no = (qty, price)
+
+# Sell YES tokens (use in should_sell_yes / go_exit_yes / update_position)
+self.sell_yes = (qty, price)
+
+# Sell NO tokens
+self.sell_no = (qty, price)
+```
+
+The default 2% Polymarket taker fee applies to all trades.
+
+---
+
+## Strategy File Structure
+
+Place your strategy in the standard directory structure:
+
+```
+strategies/
+  ValueBuyer_PM_M/
+    __init__.py      ← Your strategy implementation
+```
+
+The `__init__.py` file contains your `PolymarketStrategy` subclass. The directory name must match the class name.
+
+---
+
+## Related Documentation
+
+- [Polymarket Deployments](/guide/polymarket-deployments) — Deploy your strategy to live trading
+- [MCP Tools Reference](/guide/mcp-tools) — `create_prediction_market_strategy`, `run_prediction_market_backtest`, and other PM tools
+- [Strategy Creation](/guide/strategies) — General strategy development guide (Hyperliquid)
+- [Backtesting](/guide/backtesting) — Backtesting fundamentals

--- a/docs/guide/polymarket-strategies.md
+++ b/docs/guide/polymarket-strategies.md
@@ -21,7 +21,7 @@ Polymarket uses **YES/NO binary tokens**, not long/short positions. Prices are p
 ```python
 from jesse.strategies import PolymarketStrategy
 
-class MyStrategy_PM_15m_M(PolymarketStrategy):
+class MyStrategy_PM_M(PolymarketStrategy):
     """My prediction market strategy"""
 
     # Required methods (must implement all four)
@@ -246,6 +246,8 @@ class ValueBuyer_PM_M(PolymarketStrategy):
     Buy YES when price is low (undervalued), buy NO when YES price
     is high (overvalued). Sell when price moves toward fair value.
     Medium risk: 50% margin per trade, moderate thresholds.
+    Note: Uses 0.40 threshold (more conservative than the 0.45 guideline
+    in the naming convention table — adjust to taste).
     """
 
     # --- Required: Entry signals ---
@@ -255,7 +257,7 @@ class ValueBuyer_PM_M(PolymarketStrategy):
         return not self.yes_position.is_open and self.yes_price < 0.40
 
     def should_buy_no(self) -> bool:
-        """Buy NO when YES is expensive (> 0.60) and we don't already hold"""
+        """Buy NO when it's cheap (< 0.40) and we don't already hold"""
         return not self.no_position.is_open and self.no_price < 0.40
 
     # --- Required: Entry execution ---

--- a/docs/guide/polymarket-strategies.md
+++ b/docs/guide/polymarket-strategies.md
@@ -160,7 +160,7 @@ Rolling markets are sequential, time-bounded prediction markets on the same unde
 - Your strategy auto-transitions to the next market when the current one resolves
 - Resolution settlement happens automatically — winning tokens pay out $1.00, losing tokens expire
 - Balance carries forward between markets
-- The agent exits positions **60 seconds before resolution** to avoid holding through settlement
+- The live engine automatically exits positions **60 seconds before resolution** (`PRE_RESOLUTION_EXIT_SECONDS`) to avoid holding through settlement — this is handled at the engine level, not in your strategy code
 - Rolling markets have an `asset` (e.g., "BTC") and `interval` (e.g., "15m")
 
 ### Market Slugs
@@ -192,6 +192,8 @@ Polymarket strategies follow this naming pattern:
 | `Risk` | Risk level suffix | `L` (low), `M` (medium), `H` (high) |
 
 **Risk levels for prediction markets:**
+
+> These are recommended guidelines for strategy design, not platform-enforced constraints. You can use any margin percentage or entry threshold — these conventions help communicate intent through the strategy name suffix.
 
 | Level | Margin per Trade | Entry Threshold |
 |-------|-----------------|-----------------|

--- a/docs/guide/polymarket.md
+++ b/docs/guide/polymarket.md
@@ -1,0 +1,562 @@
+# Polymarket Strategies
+
+Robonet supports building and deploying automated strategies on [Polymarket](https://polymarket.com), the leading prediction market platform. This guide covers how to build, backtest, and deploy prediction market strategies.
+
+## What is Polymarket?
+
+Polymarket is a decentralized prediction market platform where users trade on the outcomes of real-world events. Each market has two tokens — **YES** and **NO** — priced between $0 and $1. When a market resolves, the winning token pays out $1 and the losing token pays $0.
+
+**Example:** A market asking "Will BTC be above $100k on June 1?" might have YES at $0.65 and NO at $0.35. If BTC is above $100k when the market resolves, YES holders receive $1 per token and NO holders receive $0.
+
+## Key Concepts
+
+### Markets and Events
+
+- **Event**: A top-level question or category (e.g., "2025 Fed Rate Decisions")
+- **Market**: A specific binary outcome within an event, identified by a **condition ID**
+- **Condition ID**: The unique Polymarket identifier for a market — used in all MCP tools and strategy operations
+
+### YES/NO Tokens
+
+Every market has two ERC-1155 tokens on Polygon:
+
+| Token | Priced | Resolves To |
+|-------|--------|-------------|
+| **YES** | $0–$1 | $1 if outcome happens, $0 otherwise |
+| **NO** | $0–$1 | $1 if outcome doesn't happen, $0 otherwise |
+
+YES + NO prices always approximately sum to $1. Your strategy profits by buying tokens below their fair value and either selling later at a higher price or holding to resolution.
+
+### Market Types
+
+Robonet tracks two types of prediction markets:
+
+**Single Markets** — One-time events like "Will X happen by date Y?" Identified by `condition_id`. These resolve once and are done.
+
+**Rolling Series** — Recurring crypto markets like "BTC price up or down in 15 minutes?" that repeat continuously. Identified by `asset` + `interval` (e.g., BTC + 15m). When one market resolves, the next one begins automatically. This is the primary market type for automated trading.
+
+Rolling series use a slug format: `{asset}-up-or-down-{interval}` (e.g., `btc-up-or-down-15m`).
+
+## Architecture Overview
+
+Polymarket trading on Robonet involves several components working together:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    POLYMARKET STRATEGY ARCHITECTURE                         │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ┌──────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────┐  │
+│   │   YOU    │ ──► │   ROBONET    │ ──► │   TRADING    │ ──► │POLYMARKET│  │
+│   │  (User)  │     │   BACKEND    │     │    AGENT     │     │   CLOB   │  │
+│   └──────────┘     └──────────────┘     └──────────────┘     └──────────┘  │
+│                                                                             │
+│   • Create strategy  • Deploy vault      • Execute strategy  • Match orders│
+│   • Configure params • Setup Safe wallet  • Place orders      • Settle     │
+│   • Deposit funds    • Manage lifecycle   • Manage positions    trades     │
+│                                                                             │
+│                    ┌──────────────────────────────┐                         │
+│                    │   POLYGON BLOCKCHAIN          │                        │
+│                    │                               │                        │
+│                    │  ┌──────────┐  ┌───────────┐  │                        │
+│                    │  │  GNOSIS  │  │ ERC-4626  │  │                        │
+│                    │  │   SAFE   │  │   VAULT   │  │                        │
+│                    │  │(holds $) │  │(accounting)│  │                        │
+│                    │  └──────────┘  └───────────┘  │                        │
+│                    └──────────────────────────────┘                         │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Gnosis Safe**: Holds the actual USDC funds and executes trades on Polymarket. Deployed automatically per user via a gasless relayer.
+
+**ERC-4626 Vault**: An on-chain tokenized strategy vault that tracks deposits, withdrawals, shares, and PnL. Other users can deposit into your vault.
+
+**Trading Agent**: A containerized process that runs your strategy, connects to Polymarket's CLOB API, and manages the keeper cycle (tend → report → process withdrawals).
+
+## MCP Tools
+
+Robonet provides 4 dedicated MCP tools for Polymarket. For full parameter details and usage examples, see the [MCP Tools Reference](/guide/mcp-tools#prediction-market-tools).
+
+| Tool | Purpose | Pricing |
+|------|---------|---------|
+| `get_all_prediction_events` | Browse tracked prediction events and their markets | $0.001 |
+| `get_prediction_market_data` | Get market metadata and YES/NO price timeseries | $0.001 |
+| `create_prediction_market_strategy` | AI-generate a PolymarketStrategy from a description | Max $4.50 |
+| `run_prediction_market_backtest` | Test strategy on historical market data | $0.001 |
+
+### Typical Workflow
+
+```
+1. get_all_prediction_events        → Find active markets
+2. get_prediction_market_data       → Analyze price history
+3. create_prediction_market_strategy → Build your strategy
+4. run_prediction_market_backtest   → Validate performance
+5. Deploy via chat or MCP           → Go live
+```
+
+## Building Strategies
+
+### The PolymarketStrategy Base Class
+
+All Polymarket strategies extend `PolymarketStrategy`, which provides the framework for YES/NO token trading. You implement 4 required methods:
+
+```python
+class MyStrategy_PM_M(PolymarketStrategy):
+
+    def should_buy_yes(self) -> bool:
+        """Return True when YES tokens should be purchased."""
+        return self.yes_price < 0.35
+
+    def should_buy_no(self) -> bool:
+        """Return True when NO tokens should be purchased."""
+        return self.no_price < 0.35
+
+    def go_yes(self):
+        """Execute YES purchase. Set self.buy_yes = (qty, price)."""
+        qty = self.available_margin / self.yes_price
+        self.buy_yes = qty, self.yes_price
+
+    def go_no(self):
+        """Execute NO purchase. Set self.buy_no = (qty, price)."""
+        qty = self.available_margin / self.no_price
+        self.buy_no = qty, self.no_price
+```
+
+### Naming Convention
+
+Strategy names follow the format `{Name}_PM_{Risk}` where Risk is `L` (low), `M` (medium), or `H` (high):
+- `ValueBuyer_PM_M`
+- `MomentumTrader_PM_H`
+- `MeanReversion_PM_L`
+
+### Required Methods
+
+| Method | Purpose |
+|--------|---------|
+| `should_buy_yes()` | Returns `True` when YES tokens should be bought |
+| `should_buy_no()` | Returns `True` when NO tokens should be bought |
+| `go_yes()` | Execute YES purchase — set `self.buy_yes = (qty, price)` |
+| `go_no()` | Execute NO purchase — set `self.buy_no = (qty, price)` |
+
+### Optional Methods
+
+| Method | Purpose |
+|--------|---------|
+| `should_sell_yes()` | Custom exit logic for YES positions (default: hold to resolution) |
+| `should_sell_no()` | Custom exit logic for NO positions |
+| `on_resolution(winning_side)` | Called when market resolves (`"yes"` or `"no"`) |
+| `update_position()` | Called each candle while a position is open |
+| `before()` / `after()` | Lifecycle hooks called before/after each candle |
+
+### Key Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.yes_price` | float | Current YES token price (0–1) |
+| `self.no_price` | float | Current NO token price (0–1) |
+| `self.yes_position` | Position | YES token position (qty, entry_price, pnl, is_open) |
+| `self.no_position` | Position | NO token position |
+| `self.available_margin` | float | Available USDC for new positions |
+| `self.balance` | float | Total USDC balance |
+| `self.market` | Market | Market metadata (question, outcomes, resolution) |
+| `self.is_resolved` | bool | Whether the market has resolved |
+| `self.resolution` | str/None | Resolution outcome (`"yes"`, `"no"`, or `None`) |
+| `self.yes_candles` | ndarray | YES token OHLCV candle data |
+| `self.no_candles` | ndarray | NO token OHLCV candle data |
+| `self.total_position_value` | float | Combined position value in USDC |
+| `self.total_pnl` | float | Combined unrealized PnL |
+
+### Order Variables
+
+| Variable | Description |
+|----------|-------------|
+| `self.buy_yes = (qty, price)` | Buy YES tokens |
+| `self.buy_no = (qty, price)` | Buy NO tokens |
+| `self.sell_yes = (qty, price)` | Sell YES tokens |
+| `self.sell_no = (qty, price)` | Sell NO tokens |
+
+## Strategy Examples
+
+### Example 1: Value Buyer
+
+Buy tokens when they're significantly underpriced:
+
+```python
+class ValueBuyer_PM_M(PolymarketStrategy):
+    """Buy tokens trading below fair value thresholds."""
+
+    def should_buy_yes(self) -> bool:
+        return self.yes_price < 0.30
+
+    def should_buy_no(self) -> bool:
+        return self.no_price < 0.30
+
+    def go_yes(self):
+        qty = self.available_margin * 0.5 / self.yes_price
+        self.buy_yes = qty, self.yes_price
+
+    def go_no(self):
+        qty = self.available_margin * 0.5 / self.no_price
+        self.buy_no = qty, self.no_price
+
+    def should_sell_yes(self) -> bool:
+        return self.yes_price > 0.70
+
+    def should_sell_no(self) -> bool:
+        return self.no_price > 0.70
+```
+
+### Example 2: Mean Reversion
+
+Trade token prices that deviate from recent averages:
+
+```python
+class MeanReversion_PM_M(PolymarketStrategy):
+    """Buy when price drops below moving average, sell when above."""
+
+    @property
+    def yes_ma(self):
+        """20-period moving average of YES price."""
+        if len(self.yes_candles) < 20:
+            return self.yes_price
+        return self.yes_candles[-20:, 2].mean()  # close prices
+
+    def should_buy_yes(self) -> bool:
+        return self.yes_price < self.yes_ma * 0.95  # 5% below MA
+
+    def should_buy_no(self) -> bool:
+        return self.no_price < (1 - self.yes_ma) * 0.95
+
+    def go_yes(self):
+        qty = self.available_margin * 0.4 / self.yes_price
+        self.buy_yes = qty, self.yes_price
+
+    def go_no(self):
+        qty = self.available_margin * 0.4 / self.no_price
+        self.buy_no = qty, self.no_price
+
+    def should_sell_yes(self) -> bool:
+        return self.yes_price > self.yes_ma * 1.05  # 5% above MA
+```
+
+### Creating via AI
+
+The fastest way to build a strategy is through AI generation:
+
+**Via Chat Interface:**
+```
+Create a prediction market strategy called "PriceThreshold" that:
+- Buys YES when price < 0.40 (undervalued)
+- Buys NO when price > 0.60 (overvalued)
+- Uses 50% of available margin per trade
+- Exits positions when price returns to 0.45-0.55 range
+```
+
+**Via MCP Server:**
+```
+Use create_prediction_market_strategy to build a "MomentumPM" strategy
+that follows YES/NO price momentum using a 10-period lookback
+```
+
+## Backtesting
+
+Polymarket strategies support two backtesting modes:
+
+### Single Market Backtest
+
+Test your strategy on one specific market using its condition ID:
+
+```
+Backtest "ValueBuyer_PM_M" on condition_id "0xb0eb..."
+from 2025-01-01 to 2025-01-30
+```
+
+### Rolling Market Backtest
+
+Test across a series of rolling markets. The balance carries forward between markets, simulating real rolling deployment:
+
+```
+Backtest "ValueBuyer_PM_M" on BTC 15m rolling markets
+from 2025-01-01 to 2025-01-30
+```
+
+The rolling backtest automatically:
+1. Finds all resolved markets for the given asset + interval in the date range
+2. Runs sequential backtests on each market
+3. Carries the ending balance forward to the next market
+4. Aggregates performance metrics across all markets
+
+### Backtest Metrics
+
+Both modes return:
+- **Return & PnL**: Total return, net profit/loss
+- **Risk metrics**: Sharpe ratio, Sortino ratio, max drawdown
+- **Trade stats**: Win rate, total trades, average win/loss
+- **Equity curve**: Downsampled for visualization
+
+::: tip Check Data First
+Use `get_data_availability` with `data_type="polymarket"` to verify data exists for your target market and date range before backtesting.
+:::
+
+## Deploying a Polymarket Strategy
+
+### Prerequisites
+
+Before deploying, you need:
+
+1. **Connected wallet** — Sign in with your wallet via Privy
+2. **Wallet delegation** — One-time authorization for server-side trade signing
+3. **POL on Polygon** — At least 10 POL for vault contract deployment gas
+4. **USDC.e on Polygon** — Trading capital (minimum 10 USDC)
+5. **A backtested strategy** — Validated PolymarketStrategy
+
+### What Happens When You Deploy
+
+When you deploy a Polymarket strategy, the system executes several setup steps:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    POLYMARKET DEPLOYMENT FLOW                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─────────────┐                                                            │
+│  │   DEPLOY    │                                                            │
+│  │   CLICKED   │                                                            │
+│  └──────┬──────┘                                                            │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────┐                │
+│  │  1. GNOSIS SAFE DEPLOYMENT (gasless)                    │                │
+│  │     • Derive deterministic Safe address from your wallet│                │
+│  │     • Deploy via Polymarket relayer (no gas cost)       │                │
+│  │     • Safe is reused across deployments                 │                │
+│  └─────────────────────────────────────────────────────────┘                │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────┐                │
+│  │  2. TOKEN APPROVALS (on-chain, user pays gas)           │                │
+│  │     • USDC.e approvals for Polymarket contracts         │                │
+│  │     • ERC-1155 approvals for exchange contracts         │                │
+│  │     • Batched via MultiSend for efficiency              │                │
+│  └─────────────────────────────────────────────────────────┘                │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────┐                │
+│  │  3. VAULT CONTRACT DEPLOYMENT (user pays ~0.3 POL)      │                │
+│  │     • Deploy ERC-4626 PolymarketTradingStrategy          │                │
+│  │     • Configure: TVL cap, deposit limits, keeper interval│                │
+│  │     • Set performance fee and profit unlock time         │                │
+│  └─────────────────────────────────────────────────────────┘                │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────┐                │
+│  │  4. VAULT APPROVAL ON SAFE                              │                │
+│  │     • Approve vault to spend Safe's USDC                │                │
+│  │     • Required for withdrawal processing                │                │
+│  └─────────────────────────────────────────────────────────┘                │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────┐                │
+│  │  5. AGENT LAUNCH                                        │                │
+│  │     • Package strategy + config into container          │                │
+│  │     • Deploy to isolated hosting environment            │                │
+│  │     • Agent connects to Polymarket CLOB                 │                │
+│  └─────────────────────────────────────────────────────────┘                │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────┐                                                            │
+│  │   RUNNING   │  Agent is live and trading                                │
+│  │      ✓      │                                                            │
+│  └─────────────┘                                                            │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Configuration Options
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| **Strategy** | Your PolymarketStrategy name | Required |
+| **Market** | Rolling series slug (e.g., `btc-up-or-down-15m`) | Required |
+| **Performance Fee** | Fee charged on profits (1–20%) | 10% |
+| **Max Deposit Per Wallet** | Per-wallet deposit cap in USDC | 10,000 |
+
+### Limits
+
+- Maximum **1 active Polymarket deployment** per user
+- Requires at least **10 POL** on Polygon for gas
+- Requires at least **10 USDC.e** on Polygon for trading
+
+## Vault Architecture
+
+Each Polymarket deployment creates an on-chain ERC-4626 tokenized vault on Polygon. This is the same architecture used by institutional DeFi protocols (based on the Yearn V3 pattern).
+
+### How the Vault Works
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         VAULT COMPONENTS                                    │
+├───────────────────────────────────┬─────────────────────────────────────────┤
+│       ERC-4626 VAULT CONTRACT     │           GNOSIS SAFE                   │
+├───────────────────────────────────┼─────────────────────────────────────────┤
+│                                   │                                         │
+│  • Tracks shares & accounting     │  • Holds actual USDC funds              │
+│  • Manages deposits/withdrawals   │  • Executes trades on Polymarket        │
+│  • Records PnL via keeper reports │  • Approves token contracts             │
+│  • Enforces deposit limits        │  • Deterministic per user (CREATE2)     │
+│  • ERC-20 share token             │  • Gasless deployment via relayer       │
+│                                   │                                         │
+└───────────────────────────────────┴─────────────────────────────────────────┘
+```
+
+**Deposits** flow: User → Vault Contract → Gnosis Safe (via `_deployFunds`)
+
+**Withdrawals** flow: Gnosis Safe → Vault Contract → User (via keeper fulfillment or direct withdrawal)
+
+### The Keeper Cycle
+
+The trading agent acts as a "keeper" — a privileged role that bridges offchain trading activity with onchain accounting. Every hour, the keeper runs a 3-step cycle:
+
+1. **Tend** — Reports current portfolio positions (token IDs, amounts, prices) to the vault contract. This is how the vault knows what the Safe holds.
+
+2. **Report** — Triggers PnL accounting. The vault calculates total assets from the portfolio data and updates share prices accordingly.
+
+3. **Process Withdrawals** — Iterates the withdrawal queue and fulfills pending requests by moving USDC from the Safe back to the vault.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                    KEEPER CYCLE (Hourly)                   │
+│                                                           │
+│   ┌────────┐     ┌────────┐     ┌─────────────────────┐   │
+│   │  TEND  │ ──► │ REPORT │ ──► │ PROCESS WITHDRAWALS │   │
+│   │        │     │        │     │                     │   │
+│   │ Update │     │ Update │     │ Fulfill pending     │   │
+│   │ prices │     │ PnL &  │     │ withdrawal requests │   │
+│   │ & pos. │     │ shares │     │ from queue          │   │
+│   └────────┘     └────────┘     └─────────────────────┘   │
+│                                                           │
+└───────────────────────────────────────────────────────────┘
+```
+
+### Deposits and Withdrawals
+
+**Depositing:**
+- Other users can deposit USDC into your vault and receive share tokens
+- Deposits are only accepted when the vault is active
+- Enforced by `totalAssetsLimit` and `maxDepositLimitPerWallet`
+
+**Withdrawing (active vault):**
+- Users submit a withdrawal request via `requestToWithdraw()`
+- The keeper fulfills the request during its next cycle
+- There is a slight delay (up to 1 hour) between requesting and receiving funds
+
+**Withdrawing (deactivated vault):**
+- If a vault is deactivated (emergency or shutdown), users can call `withdrawDirect()` for immediate withdrawal
+- This bypasses the keeper queue entirely
+
+::: warning Withdrawal Timing
+Withdrawals from active vaults are processed by the keeper every ~1 hour. Users won't receive funds instantly — this is by design, since the funds are actively being used for trading in the Gnosis Safe.
+:::
+
+### Activate / Deactivate
+
+The keeper can activate or deactivate a vault:
+
+| State | Deposits | Withdrawal Requests | Direct Withdrawal | Trading |
+|-------|----------|--------------------|--------------------|---------|
+| **Active** | Allowed | Allowed | Blocked | Running |
+| **Deactivated** | Blocked | Blocked | Allowed | Stopped |
+
+Deactivation acts as a kill switch — it stops all trading and allows depositors to withdraw directly without waiting for the keeper.
+
+## Live Trading Engine
+
+When deployed, the Polymarket trading agent runs a continuous loop:
+
+1. **Market Discovery** — For rolling series, the engine automatically discovers and transitions between markets. When the current market nears resolution (60 seconds before end), it exits positions and waits for the next market.
+
+2. **Candle Loop** — Every minute, the agent fetches the latest candle data from Polymarket's CLOB, updates the database, and executes the strategy.
+
+3. **Order Execution** — Orders are placed through the CLOB API using the Gnosis Safe as the trading entity. All signing is done server-side through Privy (no raw private keys).
+
+4. **Vault Keeper** — A background thread runs the hourly tend → report → withdrawal cycle to keep onchain accounting in sync.
+
+### Authentication
+
+The agent authenticates with Polymarket using:
+- **Gnosis Safe** as the trading wallet (holds funds, executes trades)
+- **Privy delegated signing** for all cryptographic operations (MPC-secured, no private key exposure)
+- **CLOB API credentials** derived from the Safe's signing authority at agent startup
+
+## Security Model
+
+| Layer | Protection |
+|-------|------------|
+| **Fund custody** | USDC held in user's Gnosis Safe on Polygon — Robonet can trade but not withdraw to external addresses |
+| **Signing** | All signatures via Privy MPC — no private keys stored or exposed |
+| **Safe deployment** | Deterministic via CREATE2 — same wallet always produces same Safe address |
+| **Token approvals** | Limited to Polymarket exchange contracts only |
+| **Vault contract** | Audited ERC-4626 pattern with reentrancy guards |
+| **Execution** | Containerized, isolated, resource-limited hosting environment |
+| **Emergency exit** | Vault deactivation + `withdrawDirect()` for immediate fund recovery |
+
+## Vault Stats and Monitoring
+
+Vault statistics are synced on-chain every 10 minutes and include:
+
+- **Total Value Locked (TVL)** — Total USDC under management
+- **Share Price** — Current price per share (reflects PnL)
+- **Total Shares** — Outstanding share supply
+- **Portfolio** — Active token positions with amounts and prices
+- **Performance** — Return percentages for 24h, 7d, 30d, and all-time
+- **Withdrawal Queue** — Pending withdrawal requests
+- **Active Status** — Whether the vault is accepting deposits
+
+Stopped and failed vaults with remaining deposits continue to be tracked so depositors can always withdraw their funds.
+
+## On-Chain Addresses
+
+### Polygon Mainnet
+
+| Contract | Address |
+|----------|---------|
+| USDC.e | `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174` |
+| CTF (Conditional Token Framework) | `0x4D97DCd97eC945f40cF65F87097ACe5EA0476045` |
+| CTF Exchange | `0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E` |
+| Neg Risk CTF Exchange | `0xC5d563A36AE78145C45a50134d48A1215220f80a` |
+| Neg Risk Adapter | `0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296` |
+
+## Tips and Best Practices
+
+**Start with backtesting:**
+- Always backtest on rolling markets before deploying — use `asset="BTC"` and `interval="15m"` to test across multiple market cycles
+- Check `get_data_availability` first to ensure sufficient historical data
+
+**Strategy design:**
+- Keep strategies simple — prediction markets have different dynamics than perpetual futures
+- Remember: prices are bounded between 0 and 1, so traditional indicators may need adaptation
+- For rolling markets, positions are automatically exited before resolution — design your logic accordingly
+
+**Position sizing:**
+- Don't go all-in — use `self.available_margin * fraction` for partial allocation
+- Account for the YES + NO price relationship when sizing positions
+
+**Deployment:**
+- Ensure you have enough POL on Polygon for gas before deploying (~10 POL)
+- Your Gnosis Safe is reused across deployments — you only deploy it once
+- Monitor vault stats through the platform dashboard
+
+**Vault management:**
+- Performance fees are charged on profits when the keeper reports
+- The profit unlock time is 2 hours — share prices update gradually, not instantly
+- If you need to shut down, deactivating the vault lets depositors withdraw directly
+
+## Related Documentation
+
+- [MCP Tools Reference](/guide/mcp-tools#prediction-market-tools) — Full tool parameter details
+- [Strategy Creation](/guide/strategies) — General strategy development guide
+- [Backtesting](/guide/backtesting) — Testing strategies on historical data
+- [Deployment](/guide/strategy-deployment) — Deployment architecture overview
+- [Trading Venues](/guide/trading-venues) — All supported trading platforms
+- [Billing & Credits](/guide/billing) — Tool pricing details

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -4,7 +4,7 @@ This guide will help you get started with Robonet in just a few minutes.
 
 ## What You Can Build
 
-Robonet enables you to create automated trading strategies that execute on Hyperliquid Perpetual markets. Here are two examples of what's possible:
+Robonet enables you to create automated trading strategies that execute on Hyperliquid Perpetual markets and Polymarket prediction markets. Here are some examples of what's possible:
 
 ### Example 1: Trend Following Strategy
 
@@ -75,7 +75,7 @@ Regardless of which interface you choose, here's the typical flow:
 2. **Backtest**: Test the strategy against historical data (default: recent 6 months)
 3. **Review Results**: Analyze performance metrics (Sharpe ratio, max drawdown, win rate)
 4. **Optimize** (optional): Fine-tune parameters to improve performance
-5. **Deploy**: Launch your strategy on Hyperliquid (EOA or Hyperliquid Vault deployment)
+5. **Deploy**: Launch your strategy on Hyperliquid (EOA or Vault) or Polymarket (Vault on Polygon)
 
 ## Next Steps
 
@@ -84,4 +84,5 @@ Once you've chosen your interface:
 - Learn about [Strategy Creation](/guide/strategies)
 - Understand [Backtesting](/guide/backtesting)
 - Explore [Allora Network Integration](/guide/allora)
-- Read about [Deployment Options](/guide/deployment)
+- Try [Polymarket Strategies](/guide/polymarket)
+- Read about [Deployment Options](/guide/strategy-deployment)

--- a/docs/guide/strategies.md
+++ b/docs/guide/strategies.md
@@ -6,6 +6,15 @@ This guide explains how to create, structure, and refine trading strategies on R
 
 Robonet strategies are Python classes that inherit from the Jesse trading framework. The platform generates strategy code based on your natural language descriptions, but understanding the structure helps you create better strategies and communicate your requirements more effectively.
 
+## Strategy Types
+
+Robonet supports two types of strategies:
+
+- **Perpetual Futures Strategies** — Trade long/short on Hyperliquid using the `Strategy` base class with `should_long()` / `should_short()` methods. Covered in this guide.
+- **Prediction Market Strategies** — Trade YES/NO tokens on Polymarket using the `PolymarketStrategy` base class with `should_buy_yes()` / `should_buy_no()` methods. See the [Polymarket Strategies guide](/guide/polymarket#building-strategies) for details.
+
+The rest of this page covers perpetual futures strategy development.
+
 ## Strategy Structure
 
 Every strategy must implement these core methods:
@@ -197,11 +206,15 @@ Strategies follow the pattern: `{Name}_{RiskLevel}[_suffix]`
 | Risk Level | H (high), M (medium), L (low) | M |
 | Suffix | Version or enhancement | _optimized, _allora, _v2 |
 
-**Examples:**
+**Perpetual Futures Examples:**
 - `RSIMeanReversion_M` - Base strategy, medium risk
 - `RSIMeanReversion_M_optimized` - After optimization
 - `RSIMeanReversion_M_allora` - With Allora ML enhancement
 - `RSIMeanReversion_M_v2` - Refined version
+
+**Prediction Market Examples** (use `_PM_` suffix):
+- `ValueBuyer_PM_M` - Polymarket strategy, medium risk
+- `MomentumTrader_PM_H` - Polymarket strategy, high risk
 
 ## Creating Strategies via Chat
 
@@ -329,5 +342,6 @@ Current coverage:
 - [Backtesting Guide](/guide/backtesting) - Test your strategies on historical data
 - [Optimization Guide](/guide/optimization) - Improve strategy parameters
 - [Allora Integration](/guide/allora) - Add ML predictions
+- [Polymarket Strategies](/guide/polymarket) - Build prediction market strategies
 - [Deployment Guide](/guide/strategy-deployment) - Deploy to live trading
 - [MCP Tools Reference](/guide/mcp-tools) - Complete tool documentation

--- a/docs/guide/strategy-deployment.md
+++ b/docs/guide/strategy-deployment.md
@@ -37,7 +37,7 @@ Robonet lets you deploy automated trading strategies that run around the clock o
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-Currently, all strategies execute on **Hyperliquid Perpetuals** — a high-performance perpetual futures DEX with on-chain settlement.
+Strategies can execute on **Hyperliquid Perpetuals** (perpetual futures DEX) or **Polymarket** (prediction markets). This page covers the Hyperliquid deployment flow. For Polymarket deployments, see the [Polymarket Strategies guide](/guide/polymarket#deploying-a-polymarket-strategy).
 
 ---
 

--- a/docs/guide/strategy-deployment.md
+++ b/docs/guide/strategy-deployment.md
@@ -37,7 +37,9 @@ Robonet lets you deploy automated trading strategies that run around the clock o
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-Currently, all strategies execute on **Hyperliquid Perpetuals** — a high-performance perpetual futures DEX with on-chain settlement.
+Strategies can execute on **Hyperliquid Perpetuals** — a high-performance perpetual futures DEX — or on **Polymarket** — a prediction market where agents trade YES/NO binary outcome tokens on Polygon.
+
+For Polymarket-specific deployment details, see the dedicated [Polymarket Deployments](/guide/polymarket-deployments) guide.
 
 ---
 
@@ -136,6 +138,22 @@ Vaults also enable **capital formation**: other users can deposit funds into you
 | **Minimum** | 200 USDC |
 | **Capital Formation** | Other users can deposit into your vault |
 | **Best For** | Multiple strategies, risk isolation, attracting investors |
+
+### Polymarket Vault
+
+Polymarket deployments use a completely different architecture from Hyperliquid — running on the **Polygon** network with an ERC4626 vault, a Safe wallet, and the Polymarket CLOB orderbook. Your agent trades YES/NO binary outcome tokens on prediction markets instead of perpetual futures.
+
+| Aspect | Details |
+|--------|---------|
+| **Network** | Polygon (Chain ID 137) |
+| **Limit** | 1 active deployment per user |
+| **Funds** | USDC.e deposited into ERC4626 vault on Polygon |
+| **Gas** | 10 POL minimum for vault deployment |
+| **Strategy class** | `PolymarketStrategy` (not `Strategy`) |
+| **Leverage** | Fixed at 1.0x |
+| **Best For** | Prediction market trading, binary outcomes |
+
+For full details on setup, vault mechanics, deposits, withdrawals, and the hourly lifecycle, see the dedicated [Polymarket Deployments](/guide/polymarket-deployments) guide. For strategy development, see [Polymarket Strategies](/guide/polymarket-strategies).
 
 ---
 

--- a/docs/guide/trading-venues.md
+++ b/docs/guide/trading-venues.md
@@ -1,6 +1,6 @@
 # Supported Trading Venues
 
-Robonet currently supports trading on **Hyperliquid Perpetual** only. Support for additional exchanges and DEXs is planned for future releases.
+Robonet supports trading on **Hyperliquid Perpetual** and **Polymarket** prediction markets.
 
 ## Decentralized Exchanges (DEXs)
 
@@ -50,6 +50,56 @@ Hyperliquid offers a wide range of perpetual futures pairs. Use the [`get_all_sy
 
 ---
 
+## Prediction Markets
+
+### Polymarket
+
+**Status:** Fully Supported (Polygon Mainnet)
+
+**Type:** Decentralized prediction market (CLOB-based)
+
+**Asset Types:**
+- Binary outcome tokens (YES/NO)
+- USDC.e denominated positions on Polygon
+
+**Market Types:**
+- **Rolling series** — Recurring crypto markets (e.g., "BTC up or down in 15m") that auto-transition between rounds
+- **Single markets** — One-time event markets with a fixed resolution date
+
+**Deployment Type:**
+- **Polymarket Vault** — ERC-4626 tokenized vault with Gnosis Safe
+  - Minimum: 10 POL for gas + 10 USDC.e for trading
+  - Maximum 1 active Polymarket deployment per user
+  - Other users can deposit into your vault
+  - Performance fees configurable (1–20%)
+
+**Network:**
+- **Polygon Mainnet** — All trading and vault contracts deployed on Polygon
+
+**Special Requirements:**
+- POL on Polygon for vault contract deployment gas (~10 POL)
+- USDC.e on Polygon for trading capital
+- Robonet credits for platform usage
+- Wallet delegation for server-side signing (via Privy)
+
+**Features:**
+- Automated rolling market transitions
+- On-chain vault accounting (ERC-4626)
+- Keeper-managed position reporting and withdrawals
+- Gasless Gnosis Safe deployment via Polymarket relayer
+- Full backtesting support (single market and rolling series)
+
+**Data Availability:**
+- Historical YES/NO token price data for backtesting
+- Multiple timeframes: 1m, 5m, 15m, 30m, 1h, 4h
+- Rolling and single market data
+
+::: tip Learn More
+See the [Polymarket Strategies guide](/guide/polymarket) for comprehensive documentation on building, backtesting, and deploying prediction market strategies.
+:::
+
+---
+
 ## Centralized Exchanges (CEXs)
 
 **Status:** Not Currently Supported
@@ -82,6 +132,7 @@ If you'd like to see support for a specific exchange or DEX, please share your f
 | Venue | Type | Asset Types | Status | Deployment Types | Min Capital |
 |-------|------|-------------|--------|------------------|-------------|
 | **Hyperliquid Perpetual** | DEX | Perpetuals | Supported | EOA, Hyperliquid Vault | 0 (EOA), 200 USDC (Hyperliquid Vault) |
+| **Polymarket** | Prediction Market | YES/NO Tokens | Supported | Polymarket Vault | 10 POL + 10 USDC.e |
 | Binance | CEX | Spot, Futures | Not Supported | - | - |
 | Bybit | CEX | Spot, Futures | Not Supported | - | - |
 | OKX | CEX | Spot, Futures | Not Supported | - | - |

--- a/docs/guide/trading-venues.md
+++ b/docs/guide/trading-venues.md
@@ -50,6 +50,46 @@ Hyperliquid offers a wide range of perpetual futures pairs. Use the [`get_all_sy
 
 ---
 
+### Polymarket
+
+**Status:** Fully Supported (Mainnet)
+
+**Type:** Decentralized prediction market
+
+**Asset Types:**
+- YES/NO binary outcome tokens
+- Rolling time-bounded markets (e.g., "BTC price in next 15m")
+- One-time event markets (e.g., "Will X happen by date Y?")
+
+**Network:** Polygon (Chain ID 137)
+
+**Currency:** USDC.e (6 decimals)
+
+**Deployment Type:**
+- **Polymarket Vault:** ERC4626 vault on Polygon with Safe wallet
+  - One active deployment per user
+  - Configurable performance fee (BPS)
+  - Configurable capacity limits
+
+**Special Requirements:**
+- Privy wallet delegation (same as Hyperliquid)
+- 10 POL minimum in wallet for vault contract deployment gas
+- USDC.e on Polygon for trading capital
+- Robonet credits for platform usage
+
+**Strategy Base Class:** [`PolymarketStrategy`](/guide/polymarket-strategies) — uses `should_buy_yes()`, `should_buy_no()`, `go_yes()`, `go_no()` instead of long/short methods.
+
+**Data Availability:**
+- Historical YES/NO token price data for backtesting
+- Default timeframe: 1m (fixed for live trading)
+- Use `get_data_availability` with `data_type="polymarket"` to check available markets
+
+**Further Reading:**
+- [Polymarket Deployments](/guide/polymarket-deployments) — Full deployment guide
+- [Polymarket Strategies](/guide/polymarket-strategies) — Strategy development
+
+---
+
 ## Centralized Exchanges (CEXs)
 
 **Status:** Not Currently Supported
@@ -82,6 +122,7 @@ If you'd like to see support for a specific exchange or DEX, please share your f
 | Venue | Type | Asset Types | Status | Deployment Types | Min Capital |
 |-------|------|-------------|--------|------------------|-------------|
 | **Hyperliquid Perpetual** | DEX | Perpetuals | Supported | EOA, Hyperliquid Vault | 0 (EOA), 200 USDC (Hyperliquid Vault) |
+| **Polymarket** | DEX | YES/NO Tokens | Supported | Polymarket Vault (ERC4626) | 10 POL + USDC.e |
 | Binance | CEX | Spot, Futures | Not Supported | - | - |
 | Bybit | CEX | Spot, Futures | Not Supported | - | - |
 | OKX | CEX | Spot, Futures | Not Supported | - | - |
@@ -132,7 +173,9 @@ Use the `get_all_symbols` MCP tool to retrieve the current list of supported tra
 ## Related Documentation
 
 - [MCP Tools Reference](/guide/mcp-tools) - See `get_all_symbols` tool for listing available pairs
-- [Wallet Integration](/guide/wallet) - Setup wallet for Hyperliquid trading
-- [Deployment Guide](/guide/deployment) - Deploy strategies to Hyperliquid (EOA or Hyperliquid Vault)
+- [Wallet Integration](/guide/wallet) - Setup wallet for Hyperliquid and Polygon trading
+- [Deployment Guide](/guide/strategy-deployment) - Deploy strategies to Hyperliquid (EOA or Hyperliquid Vault)
+- [Polymarket Deployments](/guide/polymarket-deployments) - Deploy strategies to Polymarket
+- [Polymarket Strategies](/guide/polymarket-strategies) - Build strategies for prediction markets
 - [Strategy Creation](/guide/strategies) - Build strategies for Hyperliquid
-- [Backtesting](/guide/backtesting) - Test strategies with historical Hyperliquid data
+- [Backtesting](/guide/backtesting) - Test strategies with historical data

--- a/docs/guide/trading-venues.md
+++ b/docs/guide/trading-venues.md
@@ -1,6 +1,6 @@
 # Supported Trading Venues
 
-Robonet currently supports trading on **Hyperliquid Perpetual** only. Support for additional exchanges and DEXs is planned for future releases.
+Robonet currently supports trading on **Hyperliquid** (perpetual futures) and **Polymarket** (prediction markets). Support for additional exchanges and DEXs is planned for future releases.
 
 ## Decentralized Exchanges (DEXs)
 

--- a/docs/guide/wallet.md
+++ b/docs/guide/wallet.md
@@ -46,6 +46,16 @@ Robonet integrates with two blockchain networks:
   - **EOA (Externally Owned Account):** Direct trading with your wallet (limit 1 active deployment)
   - **Hyperliquid Vault:** Create a vault (minimum 200 USDC, unlimited deployments)
 
+### Polygon Network
+- **Purpose:** Trading venue for Polymarket prediction market deployments
+- **Currency:** USDC.e stablecoin (6 decimals), POL for gas
+- **Chain ID:** 137 (mainnet)
+- **Wallet:** A **Safe wallet** is automatically derived and deployed from your Privy embedded wallet during Polymarket deployment setup. The Safe wallet holds trading positions and USDC.e on Polygon.
+- **Gas token:** POL — minimum **10 POL** required in your Privy wallet for vault contract deployment. Safe deployment and token approvals are gasless (handled by a relayer).
+- **Vault:** ERC4626 vault contract deployed on Polygon for share-based deposit/withdrawal accounting
+- **Deployment types:**
+  - **Polymarket Vault:** One active deployment per user. See [Polymarket Deployments](/guide/polymarket-deployments) for details.
+
 ::: warning Network Selection
 When depositing USDC for credits, ensure you're using the **Base network** (Chain ID 8453). Sending USDC on other networks (Ethereum mainnet, Polygon, etc.) will result in lost funds that cannot be recovered.
 :::


### PR DESCRIPTION
## Summary

Adds comprehensive Polymarket deployment documentation covering vault mechanics, strategy development, and platform integration.

Fixes ENGN-5274

## Changes

### New Pages
- **`polymarket-deployments.md`** — Full deployment guide: architecture (Polygon + Safe + ERC4626 Vault + CLOB), vault mechanics, deposit/withdraw flows (both active and deactivated paths), hourly lifecycle (tend → report → process withdrawals), fees, capacity, constraints, error troubleshooting, and Polymarket vs Hyperliquid comparison table.
- **`polymarket-strategies.md`** — Strategy development guide: PolymarketStrategy base class API, required/optional methods, properties, price constraints, resolution mechanics, rolling markets, naming conventions, backtesting modes, and example strategy walkthrough.

### Updated Pages
- **`trading-venues.md`** — Added Polymarket as a supported trading venue
- **`strategy-deployment.md`** — Added Polymarket vault deployment type with cross-link
- **`wallet.md`** — Added Polygon network (Chain ID 137), Safe wallet, POL gas requirement
- **`mcp-tools.md`** — Updated deployment_create with PM-specific params; added docs for agent_details, agent_deposit, agent_withdraw, user_position tools with PM-specific behavior
- **`.vitepress/config.ts`** — Added sidebar entries for new pages

### Review Notes
- Withdrawal flows are documented separately for active vaults (request → queue → fulfill) and deactivated vaults (direct redeem) per architect brief
- Performance fee range documented as 5-50% (MCP tool constraint) with note about backend historical range
- Pre-resolution exit clarified as engine-level automatic behavior, not strategy-author responsibility
- Uses YES/NO binary token framing throughout (no long/short language)

---

> **Note:** This PR now includes the content from #16 (Polymarket tools docs by @conache). All files from both PRs have been merged — conflicts in `strategy-deployment.md`, `trading-venues.md`, and `config.ts` were resolved by combining the best of both contributions. Nothing was lost.